### PR TITLE
build: add ddev typo3 multi version extension

### DIFF
--- a/.ddev/.typo3-setup/scripts/utils.sh
+++ b/.ddev/.typo3-setup/scripts/utils.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+
+# Function to get the lowest supported TYPO3 version from the environment variable TYPO3_VERSIONS
+# It reads the TYPO3_VERSIONS environment variable, splits it into an array, and sorts the versions.
+# If no versions are found, it prints an error message and exits with status 1.
+# Otherwise, it prints the lowest version.
+function get_lowest_supported_typo3_versions() {
+    local TYPO3_VERSIONS_ARRAY=()
+    IFS=' ' read -r -a TYPO3_VERSIONS_ARRAY <<< "$TYPO3_VERSIONS"
+    if [ ${#TYPO3_VERSIONS_ARRAY[@]} -eq 0 ]; then
+        message red "Error! No supported TYPO3 versions found in environment variables."
+        exit 1
+    fi
+    printf "%s\n" "${TYPO3_VERSIONS_ARRAY[@]}" | sort -V | head -n 1
+}
+
+# Function to get the supported TYPO3 versions from the environment variable TYPO3_VERSIONS.
+# It checks if the TYPO3_VERSIONS environment variable is set and not empty.
+# If the variable is unset or empty, it prints an error message and returns 1.
+# Otherwise, it splits the TYPO3_VERSIONS variable into an array and prints the supported versions.
+function get_supported_typo3_versions() {
+    if [ -z "${TYPO3_VERSIONS+x}" ]; then
+        message red "TYPO3_VERSIONS is unset. Please set it before running this function."
+        return 1
+    else
+        local TYPO3_VERSIONS_ARRAY=()
+        IFS=' ' read -r -a TYPO3_VERSIONS_ARRAY <<< "$TYPO3_VERSIONS"
+        if [ ${#TYPO3_VERSIONS_ARRAY[@]} -eq 0 ]; then
+            message red "Error! No supported TYPO3 versions found in environment variables."
+            return 1
+        fi
+        printf "%s\n" "${TYPO3_VERSIONS_ARRAY[@]}"
+    fi
+}
+
+# Function to check if a given TYPO3 version is supported.
+# It takes one argument, the TYPO3 version to check.
+# The function reads the supported TYPO3 versions from the environment variable TYPO3_VERSIONS.
+# If the provided version is not in the list of supported versions, it prints an error message and exits with status 1.
+# If the provided version is supported, it returns 0.
+#
+# Arguments:
+#   $1 - The TYPO3 version to check.
+#
+# Returns:
+#   0 if the provided TYPO3 version is supported.
+#   1 if the provided TYPO3 version is not supported or if no version is provided.
+function check_typo3_version() {
+    local TYPO3=$1
+    local SUPPORTED_TYPO3_VERSIONS=()
+    local found=0
+
+    if [ -z "$TYPO3" ]; then
+        message red "No TYPO3 version provided. Please set one of the supported TYPO3 versions as argument: $(get_supported_typo3_versions_comma_separated)"
+        exit 1
+    fi
+
+    while IFS= read -r line; do
+        SUPPORTED_TYPO3_VERSIONS+=("$line")
+    done < <(get_supported_typo3_versions)
+
+    for version in "${SUPPORTED_TYPO3_VERSIONS[@]}"; do
+        if [[ "$version" == "$TYPO3" ]]; then
+            found=1
+            break
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        message red "TYPO3 version '$TYPO3' is not supported."
+        exit 1
+    fi
+
+    return 0
+}
+
+# Function to perform pre-setup tasks for TYPO3 installation.
+# It exports the provided TYPO3 version to the VERSION environment variable,
+# displays an introductory message for the TYPO3 version, and starts the installation process.
+#
+# Arguments:
+#   $1 - The TYPO3 version to set up.
+#
+# Usage:
+#   pre_setup <TYPO3_VERSION>
+function pre_setup() {
+  export VERSION=$1
+  export BASE_PATH="/var/www/html/.Build/$VERSION"
+  intro_typo3
+  message blue "Pre Setup for TYPO3 $VERSION"
+  install_start
+  message blue "Install Composer Packages"
+}
+
+# Function to perform post-setup tasks for TYPO3 installation.
+# It changes the current directory to the base path, sets the TYPO3 installation database name,
+# and calls the appropriate post-setup function based on the TYPO3 version.
+# After that, it imports data and updates TYPO3.
+function post_setup() {
+  message blue "Post Setup for TYPO3 $VERSION"
+  cd $BASE_PATH
+  TYPO3_INSTALL_DB_DBNAME=$DATABASE
+
+  if [ "$VERSION" == "11" ]; then
+    post_setup_11
+  elif [ "$VERSION" == "12" ]; then
+    post_setup_12
+  elif [ "$VERSION" == "13" ]; then
+    post_setup_13
+  fi
+
+  import_data
+  update_typo3
+}
+
+# Function to display an introductory message for the TYPO3 version.
+# It prints a formatted message with the TYPO3 version in magenta color.
+function intro_typo3() {
+    message magenta "-------------------------------------------------"
+    message magenta "|\t\t\t\t\t\t|"
+    message magenta "| \t\t     TYPO3 $VERSION     \t\t|"
+    message magenta "|\t\t\t\t\t\t|"
+    message magenta "-------------------------------------------------"
+}
+
+# Function to start the installation process for TYPO3.
+# It removes any existing files in the test directory for the specified version,
+# sets up the environment, creates symlinks for the main and additional extensions,
+# and sets up Composer for the TYPO3 installation.
+function install_start() {
+    rm -rf /var/www/html/.Build/$VERSION/*
+    setup_environment
+    create_symlinks_main_extension
+    create_symlinks_additional_extensions
+    setup_composer
+}
+
+# Function to set up the environment for TYPO3 installation.
+# It sets the base path for the TYPO3 installation, removes any existing files in the base path,
+# creates necessary directories, sets permissions, and exports environment variables.
+# Additionally, it drops the existing database for the TYPO3 version.
+function setup_environment() {
+    rm -rf "$BASE_PATH"
+    mkdir -p "$BASE_PATH/packages/$EXTENSION_KEY"
+    chmod 775 -R $BASE_PATH
+    export DATABASE="database_$VERSION"
+    if [ "$VERSION" == "11" ]; then
+        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3cms"
+    else
+        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
+    fi
+    mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
+}
+
+# Function to create symlinks for the main extension.
+# It iterates over the items in the current directory, excluding certain directories and files,
+# and creates symbolic links for the remaining items in the specified base path.
+function create_symlinks_main_extension() {
+    local EXCLUSIONS_ARRAY=()
+    IFS=' ' read -r -a EXCLUSIONS_ARRAY <<< "$EXCLUSIONS"
+    for item in ./*; do
+        local base_name=$(basename "$item")
+        for exclusion in "${EXCLUSIONS_ARRAY[@]}"; do
+            if [[ $base_name == "$exclusion" ]]; then
+                continue 2
+            fi
+        done
+        ln -sr "$item" "$BASE_PATH/packages/$EXTENSION_KEY/$base_name"
+    done
+}
+
+# Function to create symlinks for additional extensions.
+# It iterates over the directories in the specified path and creates symbolic links
+# for each directory in the base path.
+function create_symlinks_additional_extensions() {
+    for dir in Tests/.typo3-setup/packages/*/; do
+        ln -sr "$dir" "$BASE_PATH/packages/$(basename "$dir")"
+    done
+}
+
+# Function to set up Composer for TYPO3 installation.
+# It initializes a new Composer project in the specified base path,
+# configures the TYPO3 web directory, sets up the repository for packages,
+# and allows necessary Composer plugins.
+function setup_composer() {
+    composer init --name="xima/typo3-$VERSION" --description="TYPO3 $VERSION" --no-interaction --working-dir "$BASE_PATH"
+    composer config extra.typo3/cms.web-dir public --working-dir "$BASE_PATH"
+    composer config repositories.packages path 'packages/*' --working-dir "$BASE_PATH"
+    composer config --no-interaction allow-plugins.typo3/cms-composer-installers true --working-dir "$BASE_PATH"
+    composer config --no-interaction allow-plugins.typo3/class-alias-loader true --working-dir "$BASE_PATH"
+}
+
+# Function to set up TYPO3 configuration.
+# It changes the current directory to the base path, sets the TYPO3 installation database name,
+# and configures various TYPO3 settings such as debug mode, error display, trusted hosts pattern,
+# mail transport, and graphics processor.
+function setup_typo3() {
+    cd $BASE_PATH
+    export TYPO3_INSTALL_DB_DBNAME=$DATABASE
+    $TYPO3_BIN configuration:set 'BE/debug' 1
+    $TYPO3_BIN configuration:set 'FE/debug' 1
+    $TYPO3_BIN configuration:set 'SYS/devIPmask' '*'
+    $TYPO3_BIN configuration:set 'SYS/displayErrors' 1
+    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' '.*.*'
+    $TYPO3_BIN configuration:set 'MAIL/transport' 'smtp'
+    $TYPO3_BIN configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
+    $TYPO3_BIN configuration:set 'GFX/processor' 'ImageMagick'
+    $TYPO3_BIN configuration:set 'GFX/processor_path' '/usr/bin/'
+}
+
+# Function to update TYPO3.
+# It updates the TYPO3 database schema and flushes the cache.
+function update_typo3() {
+    $TYPO3_BIN database:updateschema
+    $TYPO3_BIN cache:flush
+}
+
+# Function to import data into TYPO3.
+# It sets the public directory and export directory paths, checks if the data file exists,
+# and if it does, it copies the data file to the export directory and imports the data using TYPO3's import/export tool.
+function import_data() {
+    PUBLIC_DIR="/var/www/html/.Build/${VERSION}/public"
+    EXPORT_DIR="${PUBLIC_DIR}/fileadmin/user_upload/_temp_/importexport"
+    DATA_FILE="/var/www/html/Tests/.typo3-setup/data/data.xml"
+
+    if [ ! -f "$DATA_FILE" ]; then
+        message yellow "Data file $DATA_FILE not found. Skipping import."
+        return
+    fi
+
+    mkdir -p $EXPORT_DIR
+    cp /$DATA_FILE $EXPORT_DIR
+    $TYPO3_BIN impexp:import -vvv --force-uid "$EXPORT_DIR/data.xml"
+}
+
+# Function to perform post-setup tasks for TYPO3 version 11.
+# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
+# and modifying configuration files to enable deprecations and adjust base paths.
+function post_setup_11 {
+  $TYPO3_BIN install:setup -n --database-name $DATABASE
+  setup_typo3
+  $TYPO3_BIN configuration:set 'GFX/processor_path_lzw' '/usr/bin/'
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/public/typo3conf/LocalConfiguration.php
+
+  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+}
+
+# Function to perform post-setup tasks for TYPO3 version 12.
+# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
+# and modifying configuration files to enable deprecations and adjust base paths.
+function post_setup_12 {
+  $TYPO3_BIN install:setup -n --database-name $DATABASE
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+
+  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+}
+
+# Function to perform post-setup tasks for TYPO3 version 13.
+# It creates the TYPO3 database, sets up TYPO3 by running the installation setup,
+# configures TYPO3 settings, and modifies configuration files to enable deprecations.
+function post_setup_13 {
+  mysql -h db -u root -p"root" -e "CREATE DATABASE $DATABASE;"
+  $TYPO3_BIN  setup -n --dbname=$DATABASE --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.${EXTENSION_NAME}.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+}
+
+# Function to display a colored message.
+# It takes two arguments: the color and the message to display.
+# The function supports the following colors: red, green, yellow, blue, magenta, cyan.
+# If an unsupported color is provided, the message is displayed without color.
+#
+# Usage:
+#   message <color> <message>
+#
+# Arguments:
+#   color   - The color to use for the message (red, green, yellow, blue, magenta, cyan).
+#   message - The message to display.
+message() {
+    local color=$1
+    local message=$2
+
+    case $color in
+        red)
+            echo -e "\033[31m$message\033[0m"
+            ;;
+        green)
+            echo -e "\033[32m$message\033[0m"
+            ;;
+        yellow)
+            echo -e "\033[33m$message\033[0m"
+            ;;
+        blue)
+            echo -e "\033[34m$message\033[0m"
+            ;;
+        magenta)
+            echo -e "\033[35m$message\033[0m"
+            ;;
+        cyan)
+            echo -e "\033[36m$message\033[0m"
+            ;;
+        *)
+            echo -e "$message"
+            ;;
+    esac
+}

--- a/.ddev/.typo3-setup/templates/index.php
+++ b/.ddev/.typo3-setup/templates/index.php
@@ -1,0 +1,107 @@
+<?php
+
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+
+$extensionKey = getenv('EXTENSION_NAME');
+$typo3AdminUser = getenv('TYPO3_INSTALL_ADMIN_USER');
+$typo3AdminPassword = getenv('TYPO3_INSTALL_ADMIN_PASSWORD');
+$supportedVersions = explode(' ', getenv('TYPO3_VERSIONS'));
+
+// Check if composer.json exists
+$composerJsonPath = __DIR__ . '/../composer.json';
+if (file_exists($composerJsonPath)) {
+    $composerJsonContent = file_get_contents($composerJsonPath);
+    $composerData = json_decode($composerJsonContent, true);
+    $description = $composerData['description'];
+} else {
+    $description = 'composer.json file not found. =(';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><?php echo($extensionKey); ?></title>
+    <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+    >
+    <style>
+        .flex {
+            display: flex;
+            gap: 10px;
+        }
+    </style>
+</head>
+<body>
+<header class="container">
+    <h1>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-0.5 -0.5 24 24" id="Typo3-Icon--Streamline-Svg-Logos.svg" height="40" width="40"><path fill="#F49700" d="M9.895582291666667 0.5915863541666667c-0.4094479166666667 0.35015104166666666 -0.7003020833333333 0.7595869791666667 -0.7003020833333333 1.9823292708333333 0 3.32738125 4.19994375 13.322414583333334 7.060448958333334 13.322414583333334 0.32128125 0.004360416666666667 0.6412927083333333 -0.04125625 0.9485583333333334 -0.13522083333333335l-0.0060375 0.0016770833333333334 -0.07309687499999999 0.11725208333333334C14.656414583333333 19.815003125000004 11.685221875 22.70162291666667 9.887244791666667 22.759530208333334L9.832571875000001 22.760416666666668C5.927195833333333 22.760416666666668 0.38405927083333335 10.970137500000002 0.38405927083333335 5.7827270833333335c0 -0.8170270833333334 0.185265 -1.45805625 0.46686645833333335 -1.8563635416666668C2.194099375 2.2849110416666667 6.394071875000001 0.9991703125 9.895582291666667 0.5915863541666667ZM15.379429166666668 0.23958333333333334c3.616366666666667 0 7.236446875 0.5835842708333334 7.236446875 2.6252104166666665 0 4.142515625000001 -2.627055208333333 9.1632 -3.9683864583333337 9.1632 -2.391760416666667 0 -5.372680208333334 -6.652869791666666 -5.372680208333334 -9.980222291666667C13.274809375 0.5304494791666666 13.856541666666667 0.23958333333333334 15.373870833333335 0.23958333333333334h0.0055583333333333335Z" stroke-width="1"></path></svg>
+        <?php echo($extensionKey); ?></h1>
+</header>
+<main class="container">
+    <blockquote><?php echo($description); ?></blockquote>
+    <hr/>
+    <p>Run <code>ddev install all</code> to install all TYPO3 instances below:</p>
+    <?php
+    foreach ($supportedVersions as $version) {
+        $directoryPath = "/var/www/html/.Build/" . $version;
+        if (is_dir($directoryPath)) {
+            echo "<article class='flex'><kbd>{$version}</kbd><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site'>https://{$version}.{$extensionKey}.ddev.site</a><br/><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$extensionKey}.ddev.site/typo3</a></div></article>";
+        } else {
+            echo "<article>Version {$version} is not installed. Run <code>ddev install {$version}</code> to install.</article>";
+        }
+    }
+    ?>
+    <h2>Additional information</h2>
+    <h4>DDEV commands</h4>
+    <?php
+    // Directories to scan for DDEV commands
+    $directories = [
+        '/var/www/html/.ddev/commands/web',
+        '/var/www/html/.ddev/commands/host'
+    ];
+
+    foreach ($directories as $directory) {
+        foreach (new DirectoryIterator($directory) as $fileInfo) {
+            $filePath = $fileInfo->getPathname();
+            $fileName = $fileInfo->getFilename();
+
+            if ($fileName[0] === '.' || $fileInfo->isDir()) {
+                continue;
+            }
+
+            $fileContent = file($filePath);
+            if (strpos($fileContent[0], '#!/bin/bash') === 0) {
+                $description = '';
+                $usage = '';
+                $example = '';
+
+                foreach ($fileContent as $line) {
+                    if (strpos($line, '## Description:') === 0) {
+                        $description = trim(str_replace('## Description:', '', $line));
+                    } elseif (strpos($line, '## Usage:') === 0) {
+                        $usage = trim(str_replace('## Usage:', '', $line));
+                    } elseif (strpos($line, '## Example:') === 0) {
+                        $example = trim(str_replace('## Example:', '', $line));
+                    }
+                }
+
+                echo "<article><code>ddev $usage</code><br/>$description<br/> <em>Example: $example</em></article>";
+            }
+        }
+    }
+    ?>
+    <details open>
+        <summary><h4>TYPO3 Backend Credentials</h4></summary>
+        <ul>
+            <li>Username: <code><?php echo($typo3AdminUser); ?></code></li>
+            <li>Password: <code><?php echo($typo3AdminPassword); ?></code></li>
+        </ul>
+    </details>
+</main>
+
+</body>
+</html>

--- a/.ddev/addon-metadata/typo3-multi-version-extension/manifest.yaml
+++ b/.ddev/addon-metadata/typo3-multi-version-extension/manifest.yaml
@@ -1,0 +1,25 @@
+name: typo3-multi-version-extension
+repository: jackd248/ddev-typo3-multi-version-extension
+version: 0.1.0
+install_date: "2025-07-31T12:02:23+02:00"
+project_files:
+    - .typo3-setup/scripts/utils.sh
+    - .typo3-setup/templates/index.php
+    - .typo3-setup/Tests/.typo3-setup/
+    - apache/10.conf
+    - apache/20.conf
+    - commands/host/launch
+    - commands/web/.install-11
+    - commands/web/.install-12
+    - commands/web/.install-13
+    - commands/web/11
+    - commands/web/12
+    - commands/web/13
+    - commands/web/all
+    - commands/web/install
+    - docker-compose.typo3-setup.yaml
+global_files: []
+removal_actions:
+    - rm ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
+    - rm -f ${DDEV_APPROOT}/.ddev/.typo3-setup/
+    - rm -rf ${DDEV_APPROOT}/Tests/.typo3-setup/

--- a/.ddev/apache/10.conf
+++ b/.ddev/apache/10.conf
@@ -1,0 +1,43 @@
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
+<VirtualHost *:80>
+    ServerName xima-typo3-internal-news.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName xima-typo3-internal-news.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+</VirtualHost>

--- a/.ddev/apache/20.conf
+++ b/.ddev/apache/20.conf
@@ -1,0 +1,51 @@
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
+<VirtualHost *:80>
+    ServerName sub.xima-typo3-internal-news.ddev.site
+    ServerAlias *.xima-typo3-internal-news.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.xima-typo3-internal-news\.ddev\.site$
+    RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName sub.xima-typo3-internal-news.ddev.site
+    ServerAlias *.xima-typo3-internal-news.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.xima-typo3-internal-news\.ddev\.site$
+    RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+</VirtualHost>

--- a/.ddev/commands/web/.install-11
+++ b/.ddev/commands/web/.install-11
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## #ddev-generated
+. .ddev/.typo3-setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 11.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 11
+
+# Install TYPO3 and related packages using Composer.
+# This command installs the TYPO3 base distribution, TYPO3 console, and additional packages.
+# Add any additional packages you want to install to the command below.
+composer req typo3/cms-base-distribution:'^11.5' \
+        helhum/typo3-console:'^7.1' \
+        $PACKAGE_NAME:'*@dev' \
+        test/sitepackage:'*@dev' \
+        --no-progress -n -d $BASE_PATH
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/.install-12
+++ b/.ddev/commands/web/.install-12
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## #ddev-generated
+. .ddev/.typo3-setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 12.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 12
+
+# Install TYPO3 and related packages using Composer.
+# This command installs the TYPO3 base distribution, TYPO3 console, and additional packages.
+# Add any additional packages you want to install to the command below.
+composer req typo3/cms-base-distribution:'^12.4' \
+        helhum/typo3-console:'^8.1' \
+        $PACKAGE_NAME:'*@dev' \
+        test/sitepackage:'*@dev' \
+        --no-progress -n -d $BASE_PATH
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/.install-13
+++ b/.ddev/commands/web/.install-13
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## #ddev-generated
+. .ddev/.typo3-setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 13.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 13
+
+# Install TYPO3 and related packages using Composer.
+# This command installs the TYPO3 base distribution, TYPO3 console, and additional packages.
+# Add any additional packages you want to install to the command below.
+composer req typo3/cms-base-distribution:'^13.4' \
+        helhum/typo3-console:'^8.2.1' \
+        $PACKAGE_NAME:'*@dev' \
+        test/sitepackage:'*@dev' \
+        --no-progress -n -d $BASE_PATH
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/11
+++ b/.ddev/commands/web/11
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Exec command for TYPO3 instance 11.
+## Usage: 11
+## Example: "ddev 11 composer du -o" or "ddev 11 typo3 cache:flush"
+
+. .ddev/.typo3-setup/scripts/utils.sh
+
+command=$@
+version=11
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/typo3cms${command:5}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/12
+++ b/.ddev/commands/web/12
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Exec command for TYPO3 instance 12.
+## Usage: 12
+## Example: "ddev 12 composer du -o" or "ddev 12 typo3 cache:flush"
+
+. .ddev/.typo3-setup/scripts/utils.sh
+
+command=$@
+version=12
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/13
+++ b/.ddev/commands/web/13
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Exec command for TYPO3 instance 13.
+## Usage: 13
+## Example: "ddev 13 composer du -o" or "ddev 13 typo3 cache:flush"
+
+. .ddev/.typo3-setup/scripts/utils.sh
+
+command=$@
+version=13
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/all
+++ b/.ddev/commands/web/all
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Exec command for all TYPO3 instances.
+## Usage: all
+## Example: "ddev all composer du -o" or "ddev all typo3 cache:flush"
+
+. .ddev/.typo3-setup/scripts/utils.sh
+
+command=$@
+mapfile -t versions < <(get_supported_typo3_versions)
+
+for version in "${versions[@]}"; do
+    TYPO3_PATH="/var/www/html/.test/${version}"
+    if [ -d "$TYPO3_PATH" ]; then
+        if [[ $command == typo3* ]]; then
+            if [[ $version == 11 ]]; then
+                tempCommand="/usr/bin/php vendor/bin/typo3cms${command:5}"
+            else
+                tempCommand="/usr/bin/php vendor/bin/${command}"
+            fi
+        fi
+        cd $TYPO3_PATH
+        message magenta "[TYPO3 v${version}] ${tempCommand}"
+        $tempCommand
+    else
+        message red "TYPO3 instance not found for version ${version}"
+    fi
+done

--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Install TYPO3 instances.
+## Usage: install
+## Example: "ddev install" or "ddev install 12" or "ddev install all"
+
+TYPO3=${1}
+
+. .ddev/.typo3-setup/scripts/utils.sh
+
+if [ "$TYPO3" == "all" ]; then
+    mapfile -t versions < <(get_supported_typo3_versions)
+    for version in "${versions[@]}"; do
+        .ddev/commands/web/.install-$version
+    done
+else
+    if [ -z "$TYPO3" ]; then
+        TYPO3=$(get_lowest_supported_typo3_versions)
+    else
+        if ! check_typo3_version "$TYPO3"; then
+            exit 1
+        fi
+    fi
+    ".ddev/commands/web/.install-$TYPO3"
+fi

--- a/.ddev/config.typo3-setup.yaml
+++ b/.ddev/config.typo3-setup.yaml
@@ -1,0 +1,9 @@
+type: php
+docroot: .Build
+additional_hostnames:
+  - 11.xima-typo3-internal-news
+  - 12.xima-typo3-internal-news
+  - 13.xima-typo3-internal-news
+hooks:
+   post-start:
+    - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.typo3-setup/templates/* /var/www/html/.Build/

--- a/.ddev/docker-compose.typo3-setup.yaml
+++ b/.ddev/docker-compose.typo3-setup.yaml
@@ -5,7 +5,7 @@ services:
             - EXTENSION_KEY=xima_typo3_internal_news
             - EXTENSION_NAME=xima-typo3-internal-news
             - PACKAGE_NAME=xima/xima-typo3-internal-news
-            - TYPO3_VERSIONS=11 12 13
+            - TYPO3_VERSIONS=12 13
             - SYMLINK_EXCLUSIONS=.* Documentation Documentation-GENERATED-temp var vendor public
 
             # TYPO3 v11 and v12 config

--- a/.ddev/docker-compose.typo3-setup.yaml
+++ b/.ddev/docker-compose.typo3-setup.yaml
@@ -1,0 +1,33 @@
+## #ddev-generated
+services:
+    web:
+        environment:
+            - EXTENSION_KEY=xima_typo3_internal_news
+            - EXTENSION_NAME=xima-typo3-internal-news
+            - PACKAGE_NAME=xima/xima-typo3-internal-news
+            - TYPO3_VERSIONS=11 12 13
+            - SYMLINK_EXCLUSIONS=.* Documentation Documentation-GENERATED-temp var vendor public
+
+            # TYPO3 v11 and v12 config
+            - TYPO3_INSTALL_DB_DRIVER=mysqli
+            - TYPO3_INSTALL_DB_USER=root
+            - TYPO3_INSTALL_DB_PASSWORD=root
+            - TYPO3_INSTALL_DB_HOST=db
+            - TYPO3_INSTALL_DB_UNIX_SOCKET=
+            - TYPO3_INSTALL_DB_USE_EXISTING=0
+            - TYPO3_INSTALL_ADMIN_USER=admin
+            - TYPO3_INSTALL_ADMIN_PASSWORD=Password1!
+            - TYPO3_INSTALL_SITE_NAME=EXT:xima-typo3-internal-news Dev Environment
+            - TYPO3_INSTALL_SITE_SETUP_TYPE=site
+            - TYPO3_INSTALL_WEB_SERVER_CONFIG=apache
+
+            # TYPO3 v13 config
+            - TYPO3_DB_DRIVER=mysqli
+            - TYPO3_DB_USERNAME=root
+            - TYPO3_DB_PASSWORD=root
+            - TYPO3_DB_HOST=db
+            - TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
+            - TYPO3_SETUP_ADMIN_USERNAME=admin
+            - TYPO3_SETUP_ADMIN_PASSWORD=Password1!
+            - TYPO3_PROJECT_NAME=EXT:xima-typo3-internal-news Dev Environment
+            - TYPO3_SERVER_TYPE=apache

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 .php-cs-fixer.cache
 php-cs-fixer.xml
 phpstan.xml
+.Build/

--- a/Tests/.typo3-setup/data/.gitkeep
+++ b/Tests/.typo3-setup/data/.gitkeep
@@ -1,0 +1,1 @@
+#ddev-generated

--- a/Tests/.typo3-setup/packages/sitepackage/Configuration/Services.yaml
+++ b/Tests/.typo3-setup/packages/sitepackage/Configuration/Services.yaml
@@ -1,0 +1,6 @@
+#ddev-generated
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false

--- a/Tests/.typo3-setup/packages/sitepackage/README.md
+++ b/Tests/.typo3-setup/packages/sitepackage/README.md
@@ -1,0 +1,6 @@
+#ddev-generated
+# Sitepackage
+
+This is a demo sitepackage for testing purposes.
+
+Adjust them to your needs to test features of the main extension.

--- a/Tests/.typo3-setup/packages/sitepackage/composer.json
+++ b/Tests/.typo3-setup/packages/sitepackage/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "test/sitepackage",
+  "description": "typo3-natural-language-query testing",
+  "license": "GPL-2.0-or-later",
+  "type": "typo3-cms-extension",
+  "authors": [
+    {
+      "name": "#ddev-generated",
+      "email": "x@y.com"
+    }
+  ],
+  "require": {},
+  "suggest": {},
+  "conflict": {},
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "sitepackage"
+    }
+  },
+  "version": "1.0.0",
+  "autoload": {
+    "psr-4": {
+      "Test\\Sitepackage\\": "Classes/"
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated multi-version TYPO3 setup and management within DDEV, supporting versions 11, 12, and 13.
  * Added scripts for easy installation, configuration, and command execution for each TYPO3 version.
  * Provided a web-based overview page displaying project details, admin credentials, and available commands.
  * Included demo site package and configuration for testing purposes.

* **Chores**
  * Added configuration files for Apache, Docker Compose, and DDEV to streamline environment setup.
  * Updated .gitignore to exclude build artifacts.
  * Added placeholder files to ensure necessary directories are tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->