### PR TITLE
test: generate coverage via phpcov merge using pcov driver

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,7 +11,7 @@ additional_fqdns: [ ]
 database:
   type: mariadb
   version: "10.4"
-webimage_extra_packages: [ libxml2-utils ]
+webimage_extra_packages: [ libxml2-utils, php8.2-pcov ]
 use_dns_when_possible: true
 composer_version: "2"
 web_environment:

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 	},
 	"require-dev": {
 		"eliashaeussler/version-bumper": "^4.0.3",
+		"phpunit/phpcov": "^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
 		"typo3/cms-base-distribution": "^13.4 || ^14.0",
 		"typo3/cms-lowlevel": "^13.4 || ^14.0"
@@ -73,7 +74,13 @@
 		"lint": "@cgl lint",
 		"migration": "@cgl migration",
 		"sca": "@cgl sca:php",
-		"test": "@test:coverage --no-coverage",
-		"test:coverage": "XDEBUG_MODE=coverage phpunit -c phpunit.xml"
+		"test": "@test:unit",
+		"test:coverage": [
+			"@test:coverage:unit",
+			"@test:coverage:merge"
+		],
+		"test:coverage:merge": "phpcov merge --clover .Build/coverage/clover.xml --html .Build/coverage/html .Build/coverage/",
+		"test:coverage:unit": "phpunit -c phpunit.xml",
+		"test:unit": "phpunit -c phpunit.xml --no-coverage"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63dab16714f8296481f98b527a17ad1e",
+    "content-hash": "dafadba0a34927e4546a7e6f4cb3af3d",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -7263,6 +7263,68 @@
                 }
             ],
             "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpcov",
+            "version": "10.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcov.git",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.8",
+                "phpunit/php-file-iterator": "^5.1",
+                "phpunit/phpunit": "^11.5.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/version": "^5.0.2"
+            },
+            "bin": [
+                "phpcov"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "CLI frontend for php-code-coverage",
+            "homepage": "https://github.com/sebastianbergmann/phpcov",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpcov/issues",
+                "source": "https://github.com/sebastianbergmann/phpcov/tree/10.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T09:43:28+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,14 +15,10 @@
         <testsuite name="Unit">
             <directory>Tests/Unit</directory>
         </testsuite>
-        <testsuite name="Functional">
-            <directory>Tests/Functional</directory>
-        </testsuite>
     </testsuites>
     <coverage>
         <report>
-            <clover outputFile=".Build/coverage/clover.xml"/>
-            <html outputDirectory=".Build/coverage/html"/>
+            <php outputFile=".Build/coverage/unit.cov"/>
             <text outputFile="php://stdout" showOnlySummary="true"/>
         </report>
     </coverage>


### PR DESCRIPTION
## Summary

- Add `phpunit/phpcov` (`^10.0 || ^11.0 || ^13.0`; resolves to 10.0.1 on the PHP 8.2 platform) and produce coverage reports via `phpcov merge`
- PHPUnit now writes a serialized `.cov` report; `phpcov` merges it into `clover.xml` + HTML — the unit/functional-ready split matching `typo3-environment-indicator`
- Use `pcov` as the coverage driver locally (`php8.2-pcov` in `.ddev/config.yaml`) to match CI; no Xdebug required
- Drop the empty `Functional` testsuite from `phpunit.xml`

## Changes

- `composer.json` — `phpunit/phpcov` dependency; split test scripts (`test:unit`, `test:coverage:unit`, `test:coverage:merge`)
- `composer.lock` — phpcov 10.0.1
- `phpunit.xml` — coverage report emits `.cov` + text summary; Functional suite removed
- `.ddev/config.yaml` — `php8.2-pcov` added to `webimage_extra_packages`

## Verification

- `ddev composer test:coverage` → Line coverage 73.67% (Classes 70%, Methods 90%), `clover.xml` + HTML generated via phpcov
- `composer test` runs without a coverage driver (CI `test` job)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved test coverage tooling, enabling coverage reports to be generated and merged separately from test execution.
  * Expanded the development environment with an additional PHP coverage package.

* **Chores**
  * Simplified the test configuration to focus on unit tests.
  * Updated test commands to run PHPUnit directly and produce coverage output in a new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->