### PR TITLE
fix: dashboard widget modal labels and detail content width

### DIFF
--- a/Classes/Controller/DateController.php
+++ b/Classes/Controller/DateController.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use Xima\XimaTypo3InternalNews\Configuration;
 use Xima\XimaTypo3InternalNews\Domain\Repository\NewsRepository;
 use Xima\XimaTypo3InternalNews\Service\DateService;
@@ -65,6 +66,7 @@ final class DateController extends ActionController
                         'records' => $this->newsRepository->findAllByCurrentUser() ?? [],
                     ],
                 ),
+                'labels' => $this->getModalLabels(),
             ],
         );
     }
@@ -98,7 +100,22 @@ final class DateController extends ActionController
                         'dateListCount' => (array_key_exists('dateListCount', $this->configuration) ? (int) $this->configuration['dateListCount'] : 20),
                     ],
                 ),
+                'labels' => $this->getModalLabels(),
             ],
         );
+    }
+
+    /**
+     * Modal labels resolved server-side so they are available regardless of the
+     * (backend module / iframe) context the request runs in.
+     *
+     * @return array<string, string>
+     */
+    private function getModalLabels(): array
+    {
+        return [
+            'title' => (string) LocalizationUtility::translate('widget.title', 'XimaTypo3InternalNews'),
+            'close' => (string) LocalizationUtility::translate('button.close', 'XimaTypo3InternalNews'),
+        ];
     }
 }

--- a/Resources/Public/JavaScript/utils.js
+++ b/Resources/Public/JavaScript/utils.js
@@ -8,7 +8,7 @@ class InternalNewsUtils {
       .get()
       .then(async (response) => {
         const resolved = await response.resolve();
-        this.showInternalNews(TYPO3.lang !== undefined ? TYPO3.lang['internal_news.title'] : 'Internal News', resolved.result);
+        this.showInternalNews(this.title(resolved.labels), resolved.result, resolved.labels);
       });
   }
 
@@ -17,12 +17,14 @@ class InternalNewsUtils {
       .get()
       .then(async (response) => {
         const resolved = await response.resolve();
-        this.showInternalNewsList(TYPO3.lang !== undefined ? TYPO3.lang['internal_news.title'] : 'Internal News', resolved.result);
+        this.showInternalNewsList(this.title(resolved.labels), resolved.result, resolved.labels);
       });
   }
 
-  closeButton = () => ({
-    text: TYPO3.lang !== undefined ? TYPO3.lang['internal_news.close'] : 'Close',
+  title = (labels) => labels?.title ?? TYPO3.lang?.['internal_news.title'] ?? 'Internal News';
+
+  closeButton = (labels) => ({
+    text: labels?.close ?? TYPO3.lang?.['internal_news.close'] ?? 'Close',
     name: 'close',
     icon: 'actions-close',
     active: true,
@@ -32,18 +34,18 @@ class InternalNewsUtils {
     }
   })
 
-  showInternalNews = (title, description) => {
+  showInternalNews = (title, description, labels) => {
     Modal.advanced({
       title: title,
       content: document.createRange()
         .createContextualFragment(description),
       size: {width: Modal.sizes.medium, height: Modal.sizes.default},
       staticBackdrop: true,
-      buttons: [this.closeButton()]
+      buttons: [this.closeButton(labels)]
     });
   }
 
-  showInternalNewsList = (title, content) => {
+  showInternalNewsList = (title, content, labels) => {
     Modal.advanced({
       title: title,
       content: document.createRange()
@@ -61,7 +63,7 @@ class InternalNewsUtils {
           });
         });
       },
-      buttons: [this.closeButton()]
+      buttons: [this.closeButton(labels)]
     });
   }
 }

--- a/Resources/Public/Stylesheets/Backend.css
+++ b/Resources/Public/Stylesheets/Backend.css
@@ -201,8 +201,7 @@ ul.internal-news--list .internal-news:first-child {
 /* --- News detail (modal) ------------------------------------------------- */
 
 .internal-news-detail {
-    max-width: 720px;
-    margin: 0 auto;
+    margin: 0;
 }
 
 .internal-news-detail h2 {


### PR DESCRIPTION
## Summary

- Fix the missing "Close" button label when opening a news item from the dashboard widget on TYPO3 v13
- Make the detail modal content use the full modal width consistently for all news items

## Details

The close/title labels were only registered as inline labels by the toolbar template (`TYPO3.lang`). In the v13 dashboard module context the widget runs with its own `TYPO3.lang` that lacks these labels, so the modal button text resolved to `undefined`. Labels are now delivered server-side with the AJAX response, independent of the rendering context, with a resilient `labels → TYPO3.lang → fallback` lookup in JS (no more empty label).

The detail content was capped at `max-width: 720px; margin: 0 auto`, which left inconsistent whitespace left/right in the wider v14 modal. The cap is removed so content fills the modal uniformly.

## Changes

- `Classes/Controller/DateController.php` - return localized modal labels (`title`, `close`) from the detail/list AJAX actions
- `Resources/Public/JavaScript/utils.js` - consume `labels` from the AJAX response with TYPO3.lang/string fallbacks
- `Resources/Public/Stylesheets/Backend.css` - drop the 720px cap on `.internal-news-detail`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modal dialogs now show translated title and close-button text more reliably.
  * News detail views have updated spacing/alignment for a cleaner layout.

* **Bug Fixes**
  * Improved fallback handling so modal labels still appear even when localized text is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->