### PR TITLE
chore(ci): use own reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ter-publish:
-    uses: maikschneider/reusable-workflows/.github/workflows/release.yml@main
+    uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
     secrets:
       typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

- Switch the TER release workflow to the project's own reusable workflow, in line with the other xima-typo3 extensions

## Changes

- `.github/workflows/release.yml` - Use `konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main` instead of `maikschneider/reusable-workflows`; inputs (`typo3-extension-key`) and secret (`typo3-api-token`) unchanged