### PR TITLE
chore(ci): adopt gitleaks and scorecard workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   ter-publish:
     uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
+    permissions:
+      contents: write
     secrets:
       typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
     with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,17 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,12 @@
+name: Security
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
+
+jobs:
+  security:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/security.yml@main
+    permissions:
+      contents: read

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Coverage](https://img.shields.io/coverallsCoverage/github/xima-media/xima-typo3-internal-news?logo=coveralls)](https://coveralls.io/github/xima-media/xima-typo3-internal-news)
 [![CGL](https://img.shields.io/github/actions/workflow/status/xima-media/xima-typo3-internal-news/cgl.yml?label=cgl&logo=github)](https://github.com/xima-media/xima-typo3-internal-news/actions/workflows/cgl.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/xima-media/xima-typo3-internal-news/tests.yml?label=tests&logo=github)](https://github.com/xima-media/xima-typo3-internal-news/actions/workflows/tests.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/xima-media/xima-typo3-internal-news/badge)](https://securityscorecards.dev/viewer/?uri=github.com/xima-media/xima-typo3-internal-news)
 [![License](https://poser.pugx.org/xima/xima-typo3-internal-news/license)](LICENSE.md)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Coverage](https://img.shields.io/coverallsCoverage/github/xima-media/xima-typo3-internal-news?logo=coveralls)](https://coveralls.io/github/xima-media/xima-typo3-internal-news)
 [![CGL](https://img.shields.io/github/actions/workflow/status/xima-media/xima-typo3-internal-news/cgl.yml?label=cgl&logo=github)](https://github.com/xima-media/xima-typo3-internal-news/actions/workflows/cgl.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/xima-media/xima-typo3-internal-news/tests.yml?label=tests&logo=github)](https://github.com/xima-media/xima-typo3-internal-news/actions/workflows/tests.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/xima-media/xima-typo3-internal-news/badge)](https://securityscorecards.dev/viewer/?uri=github.com/xima-media/xima-typo3-internal-news)
 [![License](https://poser.pugx.org/xima/xima-typo3-internal-news/license)](LICENSE.md)
 
 </div>


### PR DESCRIPTION
## Summary
- Add gitleaks secret scanning via the shared reusable workflow
- Add OpenSSF Scorecard supply-chain scoring via the shared reusable workflow
- Grant `contents: write` to the release workflow caller (required once the repo's default token is read-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning on pushes, pull requests, and a weekly schedule.
  * Added a security-focused workflow for ongoing repository checks.
* **Bug Fixes**
  * Updated release permissions so publishing can complete reliably.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->